### PR TITLE
feat: stream card options and other improvements

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -324,6 +324,14 @@
   "userSortField": {
     "message": "Name"
   },
+  "groupedBy": {
+    "message": "Streams are grouped by $group$",
+    "placeholders": {
+      "group": {
+        "content": "$1"
+      }
+    }
+  },
   "noneGroupBy": {
     "message": "None"
   },

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -302,6 +302,9 @@
   "rerun": {
     "message": "Rerun"
   },
+  "noCategory": {
+    "message": "No category"
+  },
   "openStream": {
     "message": "Open stream"
   },

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -57,6 +57,9 @@
   "coinbase": {
     "message": "Coinbase"
   },
+  "paypal": {
+    "message": "Paypal"
+  },
   "generalSettings": {
     "message": "General settings"
   },
@@ -89,6 +92,27 @@
   },
   "badge": {
     "message": "Display badge on browser icon"
+  },
+  "customStreamCard": {
+    "message": "Custom stream card settings"
+  },
+  "useCustomStreamCard": {
+    "message": "Use custom stream card settings"
+  },
+  "useCustomThumbnail": {
+    "message": "Stream thumbnail"
+  },
+  "useCustomPlatformIcon": {
+    "message": "Stream platform icon"
+  },
+  "useCustomViewers": {
+    "message": "Stream current viewers"
+  },
+  "useCustomTitle": {
+    "message": "Stream title"
+  },
+  "useCustomCategory": {
+    "message": "Stream category"
   },
   "twitch": {
     "message": "Twitch"

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -299,6 +299,22 @@
   "search": {
     "message": "Search"
   },
+  "asc": {
+    "message": "Sorted by $type$ ascending",
+    "placeholders": {
+      "type": {
+        "content": "$1"
+      }
+    }
+  },
+  "desc": {
+    "message": "Sorted by $type$ descending",
+    "placeholders": {
+      "type": {
+        "content": "$1"
+      }
+    }
+  },
   "viewersSortField": {
     "message": "Viewers"
   },

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -438,5 +438,24 @@
   },
   "backgroundResetButton": {
     "message": "Reset application"
+  },
+  "accessTokenExpired": {
+    "message": "$platform$ access token has expired",
+    "placeholders": {
+      "platform": {
+        "content": "$1"
+      }
+    }
+  },
+  "renewAcessToken": {
+    "message": "Renew $platform$ access token",
+    "placeholders": {
+      "platform": {
+        "content": "$1"
+      }
+    }
+  },
+  "forbidPlatform": {
+    "message": "Remove platform"
   }
 }

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -57,6 +57,9 @@
   "coinbase": {
     "message": "Coinbase"
   },
+  "paypal": {
+    "message": "Paypal"
+  },
   "generalSettings": {
     "message": "Главные настройки"
   },
@@ -89,6 +92,27 @@
   },
   "badge": {
     "message": "Показывать значок с количеством активных стримов"
+  },
+  "customStreamCard": {
+    "message": "Собственные настройки карточки стрима"
+  },
+  "useCustomStreamCard": {
+    "message": "Использовать собственные настройки карточки стрима"
+  },
+  "useCustomThumbnail": {
+    "message": "Миниатюра стрима"
+  },
+  "useCustomPlatformIcon": {
+    "message": "Иконка платформы стрима"
+  },
+  "useCustomViewers": {
+    "message": "Количество зрителей стрима"
+  },
+  "useCustomTitle": {
+    "message": "Название стрима"
+  },
+  "useCustomCategory": {
+    "message": "Категория стрима"
   },
   "twitch": {
     "message": "Twitch"

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -299,6 +299,22 @@
   "search": {
     "message": "Поиск"
   },
+  "asc": {
+    "message": "Отсортировано за {type} по возростанию",
+    "placeholders": {
+      "type": {
+        "content": "$1"
+      }
+    }
+  },
+  "desc": {
+    "message": "Отсортировано за {type} по убыванию",
+    "placeholders": {
+      "type": {
+        "content": "$1"
+      }
+    }
+  },
   "viewersSortField": {
     "message": "Зрители"
   },

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -438,5 +438,24 @@
   },
   "backgroundResetButton": {
     "message": "Перезапустить приложение"
+  },
+  "accessTokenExpired": {
+    "message": "Токен доступа $platform$ истек",
+    "placeholders": {
+      "platform": {
+        "content": "$1"
+      }
+    }
+  },
+  "renewAcessToken": {
+    "message": "Обновить токен доступа $platform$",
+    "placeholders": {
+      "platform": {
+        "content": "$1"
+      }
+    }
+  },
+  "forbidPlatform": {
+    "message": "Убрать платформу"
   }
 }

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -324,6 +324,14 @@
   "userSortField": {
     "message": "Имя"
   },
+  "groupedBy": {
+    "message": "Стримы сгрупированны как $group$",
+    "placeholders": {
+      "group": {
+        "content": "$1"
+      }
+    }
+  },
   "noneGroupBy": {
     "message": "Отсутствует"
   },

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -302,6 +302,9 @@
   "rerun": {
     "message": "Повтор"
   },
+  "noCategory": {
+    "message": "Без категории"
+  },
   "openStream": {
     "message": "Открыть стрим"
   },

--- a/public/_locales/uk/messages.json
+++ b/public/_locales/uk/messages.json
@@ -57,6 +57,9 @@
   "coinbase": {
     "message": "Coinbase"
   },
+  "paypal": {
+    "message": "Paypal"
+  },
   "generalSettings": {
     "message": "Основні налаштування"
   },
@@ -89,6 +92,27 @@
   },
   "badge": {
     "message": "Відображати значок з кількістю активних каналів"
+  },
+  "customStreamCard": {
+    "message": "Власні налаштування картки трансляції"
+  },
+  "useCustomStreamCard": {
+    "message": "Використовувати власні налаштування картки трансляції"
+  },
+  "useCustomThumbnail": {
+    "message": "Мініатюра трансляції"
+  },
+  "useCustomPlatformIcon": {
+    "message": "Іконка платформи трансляції"
+  },
+  "useCustomViewers": {
+    "message": "Кількість глядачів трансляції"
+  },
+  "useCustomTitle": {
+    "message": "Назва трансляції"
+  },
+  "useCustomCategory": {
+    "message": "Категорія трансляції"
   },
   "twitch": {
     "message": "Twitch"

--- a/public/_locales/uk/messages.json
+++ b/public/_locales/uk/messages.json
@@ -299,6 +299,22 @@
   "search": {
     "message": "Пошук"
   },
+  "asc": {
+    "message": "Відсортовано за {type} по зростанню",
+    "placeholders": {
+      "type": {
+        "content": "$1"
+      }
+    }
+  },
+  "desc": {
+    "message": "Відсортовано за {type} по спаданню",
+    "placeholders": {
+      "type": {
+        "content": "$1"
+      }
+    }
+  },
   "viewersSortField": {
     "message": "Глядачі"
   },

--- a/public/_locales/uk/messages.json
+++ b/public/_locales/uk/messages.json
@@ -302,6 +302,9 @@
   "rerun": {
     "message": "Повтор"
   },
+  "noCategory": {
+    "message": "Без категорії"
+  },
   "openStream": {
     "message": "Відкрити стрим"
   },

--- a/public/_locales/uk/messages.json
+++ b/public/_locales/uk/messages.json
@@ -324,6 +324,14 @@
   "userSortField": {
     "message": "Ім'я"
   },
+  "groupedBy": {
+    "message": "Трансляції згруповані як $group$",
+    "placeholders": {
+      "group": {
+        "content": "$1"
+      }
+    }
+  },
   "noneGroupBy": {
     "message": "Немає"
   },

--- a/public/_locales/uk/messages.json
+++ b/public/_locales/uk/messages.json
@@ -438,5 +438,24 @@
   },
   "backgroundResetButton": {
     "message": "Перезапустити застосунок"
+  },
+  "accessTokenExpired": {
+    "message": "Токен доступу $platform$ застарів",
+    "placeholders": {
+      "platform": {
+        "content": "$1"
+      }
+    }
+  },
+  "renewAcessToken": {
+    "message": "Оновити токен $platform$",
+    "placeholders": {
+      "platform": {
+        "content": "$1"
+      }
+    }
+  },
+  "forbidPlatform": {
+    "message": "Видалити платформу"
   }
 }

--- a/src/background/actions/platform.ts
+++ b/src/background/actions/platform.ts
@@ -67,7 +67,6 @@ export async function setupPlatform(
     platform.enabled = true;
     platform.accessToken = accessToken;
     await stores[`${platform.name}`].set(platform);
-    console.log(platform);
     return await updatePlatform(platform);
   }
 

--- a/src/background/actions/streams.ts
+++ b/src/background/actions/streams.ts
@@ -108,7 +108,7 @@ const newStreamNotification = async (
 
   createNotification([NotificationType.STREAM, JSON.stringify(stream)], {
     title: t("streamerOnline", [user, platform]),
-    message: game ?? "",
+    message: game ?? t("noCategory"),
     contextMessage: title,
     type: "basic",
     iconUrl: icon,
@@ -127,7 +127,7 @@ const newCategoryNotification = async (
   if (oldStream.game !== game) {
     createNotification([NotificationType.STREAM, JSON.stringify(newStream)], {
       title: t("streamerNewCategory", user),
-      message: t("streamerNewCategoryMessage", [oldStream.game, game]),
+      message: t("streamerNewCategoryMessage", [oldStream.game, game || t("noCategory")]),
       contextMessage: title,
       type: "basic",
       iconUrl: icon,

--- a/src/browser/common/hooks/platform.ts
+++ b/src/browser/common/hooks/platform.ts
@@ -1,6 +1,7 @@
 import { stores } from "@/common/store";
 import { PlatformName } from "@/common/types/platform";
 import { get } from "lodash-es";
+import { useMemo } from "react";
 import { useStore } from "./store";
 
 export function usePlatform(name: PlatformName) {
@@ -17,4 +18,12 @@ export function useAllSetPlatforms() {
   if (goodgame.enabled) allSetProfiles.push({ platform: goodgame, store: goodgameStore });
 
   return allSetProfiles;
+}
+
+export function useAllExpiredPlatforms() {
+  const [twitch] = usePlatform(PlatformName.TWITCH);
+
+  return useMemo(() => {
+    return twitch.accessToken === undefined && twitch.enabled ? twitch : null;
+  }, [twitch]);
 }

--- a/src/browser/components/cards/platform/Platform.tsx
+++ b/src/browser/components/cards/platform/Platform.tsx
@@ -9,11 +9,10 @@ interface PlatformProps {
 }
 
 const PlatformCard: FC<PlatformProps> = ({ platformName, platformType }) => {
-  return platformType === PlatformType.AUTH ? (
-    <AuthPlatform {...{ platformName }} />
-  ) : (
-    <GeneralPlatform {...{ platformName }} />
-  );
+  if (platformType === PlatformType.AUTH) {
+    return <AuthPlatform {...{ platformName }} />;
+  }
+  return <GeneralPlatform {...{ platformName }} />;
 };
 
 export default PlatformCard;

--- a/src/browser/components/cards/platform/variants/auth/AuthPlatform.tsx
+++ b/src/browser/components/cards/platform/variants/auth/AuthPlatform.tsx
@@ -10,16 +10,18 @@ interface AuthPlatformProps {
 }
 
 const AuthPlatform: FC<AuthPlatformProps> = ({ platformName }) => {
-  const [platform, { isLoading }] = usePlatform(platformName);
+  const [platform, store] = usePlatform(platformName);
   const { data } = platform;
 
-  return isLoading ? (
-    <PlatformLoading />
-  ) : platform.enabled && data ? (
-    <SetAuthProfile {...{ platformName }} />
-  ) : (
-    <UnsetAuthProfile {...{ platformName }} />
-  );
+  if (store.isLoading) {
+    return <PlatformLoading />;
+  }
+
+  if (platform.enabled && data) {
+    return <SetAuthProfile {...{ platformName }} />;
+  }
+
+  return <UnsetAuthProfile {...{ platformName }} />;
 };
 
 export default AuthPlatform;

--- a/src/browser/components/cards/stream/Details/Viewers.tsx
+++ b/src/browser/components/cards/stream/Details/Viewers.tsx
@@ -28,7 +28,11 @@ const Viewers: FC<ViewersProps> = ({ count, type }) => {
   const rerun = type === "rerun";
 
   return (
-    <Tooltip title={<Typography>{!rerun ? t("live") : t("rerun")}</Typography>} placement="left">
+    <Tooltip
+      enterNextDelay={1000}
+      title={<Typography>{!rerun ? t("live") : t("rerun")}</Typography>}
+      placement="left"
+    >
       <Box className="viewers" sx={styles}>
         <Typography className={!rerun ? "online" : ""} variant={"body2"}>
           {digitWithSpaces(count)}

--- a/src/browser/components/cards/stream/Skeleton.tsx
+++ b/src/browser/components/cards/stream/Skeleton.tsx
@@ -1,19 +1,8 @@
-import { Stream } from "@/common/types/stream";
-import { Box, Link, Tooltip, Typography } from "@mui/material";
+import { Box, Link, Skeleton, Tooltip, Typography } from "@mui/material";
 import { FC } from "react";
-import Uptime from "./details/Uptime";
-import Image from "../../misc/Image";
-import Viewers from "./details/Viewers";
-import StreamContextMenu from "../../pages/Streams/ContextMenu";
-import PlatformIcon from "../../misc/PlatformIcon";
 import { getLinkForPlatform, t } from "@/common/helpers";
 import { LinkType } from "@/common/types/general";
 import useSettings from "@/browser/common/hooks/settings";
-import StreamCardSkeleton from "./Skeleton";
-
-interface StreamCardProps {
-  readonly stream: Stream;
-}
 
 const styles = {
   "& .stream": {
@@ -60,6 +49,7 @@ const styles = {
       justifyContent: "center",
       overflow: "hidden",
       width: "100%",
+      gap: 0.5,
       "& .mainWrapper": {
         display: "flex",
         justifyContent: "space-between",
@@ -67,6 +57,7 @@ const styles = {
           display: "flex",
           alignItems: "center",
           flexDirection: "row",
+          gap: 0.5,
           "& svg": {
             mr: ".5rem",
             fontSize: "1rem",
@@ -84,8 +75,7 @@ const styles = {
   },
 };
 
-const StreamCard: FC<StreamCardProps> = ({ stream }) => {
-  const { user, viewers, title, game, thumbnail, startedAt, type, platform } = stream;
+const StreamCardSkeleton: FC = () => {
   const [
     {
       general: { useCustomStreamCard, customStreamCard },
@@ -94,24 +84,16 @@ const StreamCard: FC<StreamCardProps> = ({ stream }) => {
   ] = useSettings();
 
   if (store.isLoading) {
-    return <StreamCardSkeleton />;
+    return null;
   }
 
   return (
     <Box sx={styles}>
-      <StreamContextMenu stream={stream} />
-      <Link
-        id={user}
-        href={getLinkForPlatform(stream, LinkType.STREAM)}
-        target="_blank"
-        className="stream"
-      >
+      <Box className={"stream"}>
         {(!useCustomStreamCard || (useCustomStreamCard && customStreamCard.thumbnail)) && (
           <Box className="thumbnail">
             <Box className="thumbnailWrapper">
-              <Image src={thumbnail} alt={user} className="image" />
-
-              {startedAt && <Uptime startedAt={startedAt} className="uptime" />}
+              <Skeleton variant="rectangular" width={"100%"} height={"100%"} />
             </Box>
           </Box>
         )}
@@ -119,41 +101,28 @@ const StreamCard: FC<StreamCardProps> = ({ stream }) => {
           <Box className="mainWrapper">
             <Box className="main">
               {(!useCustomStreamCard || (useCustomStreamCard && customStreamCard.platformIcon)) && (
-                <PlatformIcon platformName={platform} />
+                <Skeleton variant="circular" width={"20px"} height={"20px"} />
               )}
 
-              <Typography noWrap variant={"body2"}>
-                {user}
-              </Typography>
+              <Skeleton variant="rectangular" width={"80px"} height={"14px"} />
             </Box>
 
             {(!useCustomStreamCard || (useCustomStreamCard && customStreamCard.viewers)) && (
-              <Viewers type={type} count={viewers} />
+              <Skeleton variant="rectangular" width={"60px"} height={"14px"} />
             )}
           </Box>
 
           {(!useCustomStreamCard || (useCustomStreamCard && customStreamCard.title)) && (
-            <Tooltip
-              title={<Typography>{title}</Typography>}
-              enterNextDelay={1000}
-              followCursor
-              arrow
-            >
-              <Typography noWrap color="text.secondary">
-                {title}&nbsp;
-              </Typography>
-            </Tooltip>
+            <Skeleton variant="rectangular" width={"100"} height={"12px"} />
           )}
 
           {(!useCustomStreamCard || (useCustomStreamCard && customStreamCard.category)) && (
-            <Typography className="game" noWrap>
-              {game || t("noCategory")}&nbsp;
-            </Typography>
+            <Skeleton variant="rectangular" width={"100"} height={"12px"} />
           )}
         </Box>
-      </Link>
+      </Box>
     </Box>
   );
 };
 
-export default StreamCard;
+export default StreamCardSkeleton;

--- a/src/browser/components/cards/stream/Stream.tsx
+++ b/src/browser/components/cards/stream/Stream.tsx
@@ -126,11 +126,9 @@ const StreamCard: FC<StreamCardProps> = ({ stream }) => {
             </Typography>
           </Tooltip>
 
-          <Tooltip title={<Typography>{game}</Typography>} enterNextDelay={1000} followCursor arrow>
-            <Typography className="game" noWrap>
-              {game || t("noCategory")}&nbsp;
-            </Typography>
-          </Tooltip>
+          <Typography className="game" noWrap>
+            {game || t("noCategory")}&nbsp;
+          </Typography>
         </Box>
       </Link>
     </Box>

--- a/src/browser/components/cards/stream/Stream.tsx
+++ b/src/browser/components/cards/stream/Stream.tsx
@@ -6,7 +6,7 @@ import Image from "../../misc/Image";
 import Viewers from "./details/Viewers";
 import StreamContextMenu from "../../pages/Streams/ContextMenu";
 import PlatformIcon from "../../misc/PlatformIcon";
-import { getLinkForPlatform } from "@/common/helpers";
+import { getLinkForPlatform, t } from "@/common/helpers";
 import { LinkType } from "@/common/types/general";
 
 interface StreamCardProps {
@@ -122,22 +122,15 @@ const StreamCard: FC<StreamCardProps> = ({ stream }) => {
             arrow
           >
             <Typography noWrap color="text.secondary">
-              {title}
+              {title}&nbsp;
             </Typography>
           </Tooltip>
 
-          {game && (
-            <Tooltip
-              title={<Typography>{game}</Typography>}
-              enterNextDelay={1000}
-              followCursor
-              arrow
-            >
-              <Typography className="game" noWrap>
-                {game}
-              </Typography>
-            </Tooltip>
-          )}
+          <Tooltip title={<Typography>{game}</Typography>} enterNextDelay={1000} followCursor arrow>
+            <Typography className="game" noWrap>
+              {game || t("noCategory")}&nbsp;
+            </Typography>
+          </Tooltip>
         </Box>
       </Link>
     </Box>

--- a/src/browser/components/modals/BackgroundReset.tsx
+++ b/src/browser/components/modals/BackgroundReset.tsx
@@ -32,20 +32,20 @@ const styles = {
 };
 
 interface BackgroundResetProps {
-  readonly isOpen: boolean;
+  readonly open: boolean;
 }
 
-const BackgroundReset: FC<BackgroundResetProps> = ({ isOpen }) => {
+const BackgroundReset: FC<BackgroundResetProps> = ({ open }) => {
   return (
     <Portal>
       <Modal
         id="backgroundResetModal"
-        open={isOpen}
+        open={open}
         sx={styles}
         // TODO: fix backdrop behavior
         // BackdropComponent={Backdrop}
       >
-        <Fade in={isOpen}>
+        <Fade in={open}>
           <Box className="wrapper">
             <Box className="background">
               <Box className="content">

--- a/src/browser/components/modals/Donate.tsx
+++ b/src/browser/components/modals/Donate.tsx
@@ -66,6 +66,7 @@ const styles = {
 
 const links = [
   { href: "https://nether0ne.github.io/#/r/streams-live-coinbase", label: t("coinbase") },
+  { href: "https://nether0ne.github.io/#/r/streams-live-paypal", label: t("paypal") },
 ];
 
 const DonateModal: FC<DonateModalProps> = ({ open, hide }) => {

--- a/src/browser/components/modals/PlatformExpired.tsx
+++ b/src/browser/components/modals/PlatformExpired.tsx
@@ -1,0 +1,93 @@
+import { sendRuntimeMessage, t } from "@/common/helpers";
+import {
+  Fade,
+  Typography,
+  Portal,
+  Backdrop,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  Button,
+  DialogActions,
+  Box,
+} from "@mui/material";
+import { FC } from "react";
+import { usePlatform } from "@/browser/common/hooks/platform";
+import { PlatformName } from "@/common/types/platform";
+import { stores } from "@/common/store";
+
+interface PlatformExpiredModalProps {
+  readonly open: boolean;
+  readonly platformName: PlatformName;
+}
+
+const styles = {
+  zIndex: 2000,
+  backdropFilter: "blur(2px)",
+  "& .header": {
+    padding: "1rem",
+    "& .text": {
+      px: "1rem",
+    },
+    "& .actions": {
+      px: "1rem",
+      pb: ".75rem",
+    },
+  },
+};
+
+const PlatformExpiredModal: FC<PlatformExpiredModalProps> = ({ open, platformName }) => {
+  const [platform] = usePlatform(platformName);
+
+  const handleUnset = async () => {
+    platform.enabled = false;
+    platform.data = {
+      id: null,
+      name: null,
+      avatar: null,
+    };
+    platform.followedStreamers = [];
+    platform.accessToken = undefined;
+    await stores[platformName].set(platform);
+    sendRuntimeMessage("updateStreams", true);
+  };
+
+  const handleConfirm = () => sendRuntimeMessage("authInit", platformName);
+
+  return (
+    <Portal>
+      <Fade in={open}>
+        <Box>
+          <Dialog
+            id="platformExpiredModal"
+            open={open}
+            TransitionComponent={Fade}
+            keepMounted
+            sx={styles}
+          >
+            <DialogTitle className="header">
+              <Typography variant="body2">{t("accessTokenExpired", [t(platformName)])}</Typography>
+            </DialogTitle>
+
+            <DialogActions className="actions">
+              <Button variant="outlined" color="info" size="small" onClick={handleConfirm}>
+                <Typography>{t("renewAcessToken", [t(platformName)])}</Typography>
+              </Button>
+              <Button
+                variant="outlined"
+                color="error"
+                size="small"
+                onClick={async () => await handleUnset()}
+              >
+                <Typography>{t("forbidPlatform")}</Typography>
+              </Button>
+            </DialogActions>
+          </Dialog>
+        </Box>
+      </Fade>
+    </Portal>
+  );
+};
+
+export default PlatformExpiredModal;

--- a/src/browser/components/pages/Settings/Extra.tsx
+++ b/src/browser/components/pages/Settings/Extra.tsx
@@ -6,7 +6,7 @@ import ResetSetting from "./options/extra/Reset";
 
 const ExtraSettings: FC = () => {
   return (
-    <Box id="extra">
+    <Box>
       <ExportSetting />
       <ImportSetting />
       <ResetSetting />

--- a/src/browser/components/pages/Settings/General.tsx
+++ b/src/browser/components/pages/Settings/General.tsx
@@ -16,7 +16,7 @@ const GeneralSettings: FC = () => {
   const onBadgeChange = async () => await sendRuntimeMessage("updateBadge");
 
   return (
-    <Box id="general" sx={styles}>
+    <Box sx={styles}>
       <FontSizeSetting />
       <ThemeSettings />
       <SwitchSettings

--- a/src/browser/components/pages/Settings/Notifications.tsx
+++ b/src/browser/components/pages/Settings/Notifications.tsx
@@ -7,18 +7,28 @@ import SwitchLeftIcon from "@mui/icons-material/SwitchLeft";
 import useSettings from "@/browser/common/hooks/settings";
 import { useAllSetPlatforms } from "@/browser/common/hooks/platform";
 import PlatformIcon from "../../misc/PlatformIcon";
+import SettingLoading from "./options/SettingLoading";
 
 const styles = {
   display: "flex",
   flexDirection: "column",
+  loading: {
+    px: 1,
+    py: 2,
+  },
 };
 
 const NotificationsSettings: FC = () => {
-  const [{ notifications }] = useSettings();
+  const [settings, store] = useSettings();
+  const { notifications } = settings;
   const setPlatforms = useAllSetPlatforms();
 
+  if (store.isLoading) {
+    return <SettingLoading withSwitch icon={<NotificationsIcon />} sx={styles.loading} />;
+  }
+
   return (
-    <Box id="notifications" sx={styles}>
+    <Box sx={styles}>
       <SwitchSettings
         {...{
           id: "notificationsEnabled",

--- a/src/browser/components/pages/Settings/StreamCardSettings.tsx
+++ b/src/browser/components/pages/Settings/StreamCardSettings.tsx
@@ -1,0 +1,90 @@
+import { Box, Collapse, Typography } from "@mui/material";
+import { FC } from "react";
+import { t } from "@/common/helpers";
+import useSettings from "@/browser/common/hooks/settings";
+import DashboardCustomizeIcon from "@mui/icons-material/DashboardCustomize";
+import PanoramaIcon from "@mui/icons-material/Panorama";
+import CastIcon from "@mui/icons-material/Cast";
+import PeopleIcon from "@mui/icons-material/People";
+import TitleIcon from "@mui/icons-material/Title";
+import CategoryIcon from "@mui/icons-material/Category";
+import SwitchSettings from "./options/Switch";
+import SettingLoading from "./options/SettingLoading";
+
+const styles = {
+  display: "flex",
+  flexDirection: "column",
+  gap: ".25rem",
+  loading: {
+    px: 1,
+    py: 2,
+  },
+};
+
+const customStreamCardSettings = {
+  thumbnail: {
+    id: "thumbnail",
+    label: t("useCustomThumbnail"),
+    icon: <PanoramaIcon />,
+  },
+  platformIcon: {
+    id: "platformIcon",
+    label: t("useCustomPlatformIcon"),
+    icon: <CastIcon />,
+  },
+  viewers: {
+    id: "viewers",
+    label: t("useCustomViewers"),
+    icon: <PeopleIcon />,
+  },
+  title: {
+    id: "title",
+    label: t("useCustomTitle"),
+    icon: <TitleIcon />,
+  },
+  category: {
+    id: "category",
+    label: t("useCustomCategory"),
+    icon: <CategoryIcon />,
+  },
+};
+
+const StreamCardSettings: FC = () => {
+  const [settings, store] = useSettings();
+  const { general } = settings;
+  const { useCustomStreamCard } = general;
+
+  if (store.isLoading) {
+    return <SettingLoading withSwitch icon={<DashboardCustomizeIcon />} sx={styles.loading} />;
+  }
+
+  return (
+    <Box sx={styles}>
+      <SwitchSettings
+        {...{
+          id: "useCustomStreamCard",
+          label: t("useCustomStreamCard"),
+          icon: <DashboardCustomizeIcon />,
+          secondaryText: true,
+          setting: "general.useCustomStreamCard",
+        }}
+      />
+
+      <Collapse in={useCustomStreamCard}>
+        {Object.values(customStreamCardSettings).map(({ id, icon, label }) => (
+          <SwitchSettings
+            {...{
+              id: `general.customStreamCard.${id}`,
+              label,
+              icon,
+              secondaryText: true,
+              setting: `general.customStreamCard.${id}`,
+            }}
+          />
+        ))}
+      </Collapse>
+    </Box>
+  );
+};
+
+export default StreamCardSettings;

--- a/src/browser/components/pages/Settings/options/SettingLoading.tsx
+++ b/src/browser/components/pages/Settings/options/SettingLoading.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react";
-import { Box, Skeleton, Switch } from "@mui/material";
+import { Box, Skeleton, Switch, SxProps } from "@mui/material";
 
 const styles = {
   display: "flex",
@@ -27,15 +27,17 @@ interface SettingLoadingProps {
   readonly icon?: JSX.Element;
   readonly secondaryText?: boolean;
   readonly withSwitch?: boolean;
+  readonly sx?: SxProps;
 }
 
 const SettingLoading: FC<SettingLoadingProps> = ({
   secondaryText = true,
   withSwitch = false,
   icon,
+  sx = {},
 }) => {
-  return withSwitch ? (
-    <Box sx={styles}>
+  return (
+    <Box sx={{ ...styles, ...sx }}>
       {icon}
 
       <Box className="text">
@@ -43,14 +45,11 @@ const SettingLoading: FC<SettingLoadingProps> = ({
         {secondaryText && <Skeleton className="secondary" />}
       </Box>
 
-      <Skeleton className="right">
-        <Switch />
-      </Skeleton>
-    </Box>
-  ) : (
-    <Box sx={styles} className="text">
-      <Skeleton className="main" />
-      {secondaryText && <Skeleton className="secondary" />}
+      {withSwitch && (
+        <Skeleton className="right">
+          <Switch />
+        </Skeleton>
+      )}
     </Box>
   );
 };

--- a/src/browser/components/pages/Settings/options/Switch.tsx
+++ b/src/browser/components/pages/Settings/options/Switch.tsx
@@ -49,7 +49,7 @@ const SwitchSettings: FC<SwitchProps> = ({
   const [settings, store] = useSettings();
   const state = get(settings, setting);
 
-  const handleThemeDivClick = () => {
+  const handleSwitchChange = () => {
     set(settings, setting, !state);
 
     store.set({
@@ -60,7 +60,7 @@ const SwitchSettings: FC<SwitchProps> = ({
   };
 
   return (
-    <SettingWrapper id={id} customStyles={styles} onClick={handleThemeDivClick}>
+    <SettingWrapper id={id} customStyles={styles} onClick={handleSwitchChange}>
       {store.isLoading ? (
         <SettingLoading withSwitch {...{ secondaryText, icon }} />
       ) : (

--- a/src/browser/components/pages/Streams/Settings.tsx
+++ b/src/browser/components/pages/Streams/Settings.tsx
@@ -1,8 +1,8 @@
 import { Box } from "@mui/material";
 import { FC } from "react";
-import SortField from "./Settings/SortField";
-import SortDirection from "./Settings/SortDirection";
-import GroupBy from "./Settings/GroupBy";
+import SortField from "./settings/SortField";
+import SortDirection from "./settings/SortDirection";
+import GroupBy from "./settings/GroupBy";
 
 const styles = {
   display: "flex",

--- a/src/browser/components/pages/Streams/Settings/GroupBy.tsx
+++ b/src/browser/components/pages/Streams/Settings/GroupBy.tsx
@@ -1,7 +1,14 @@
 import { ChangeEvent, FC, useContext } from "react";
 import { StreamSettingsContext } from "@/browser/common/context/StreamsSettings";
 import { GroupBy as GroupByEnum } from "@/common/types/settings";
-import { MenuItem, Skeleton, StandardTextFieldProps, TextField } from "@mui/material";
+import {
+  MenuItem,
+  Skeleton,
+  StandardTextFieldProps,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
 import { t } from "@/common/helpers";
 
 const loadingStyle = {
@@ -54,13 +61,19 @@ const GroupBy: FC = () => {
   return settingsIsLoading ? (
     <Skeleton sx={loadingStyle} />
   ) : (
-    <TextField id="groupBy" {...selectProps} value={groupBy} onChange={changeGroupBy}>
-      {groupByOptions.map((option) => (
-        <MenuItem key={option} value={option}>
-          {t(`${option}GroupBy`)}
-        </MenuItem>
-      ))}
-    </TextField>
+    <Tooltip
+      enterNextDelay={1000}
+      title={<Typography>{t("groupedBy", [t(`${groupBy}GroupBy`)])}</Typography>}
+      placement="top"
+    >
+      <TextField id="groupBy" {...selectProps} value={groupBy} onChange={changeGroupBy}>
+        {groupByOptions.map((option) => (
+          <MenuItem key={option} value={option}>
+            {t(`${option}GroupBy`)}
+          </MenuItem>
+        ))}
+      </TextField>
+    </Tooltip>
   );
 };
 

--- a/src/browser/components/pages/Streams/Settings/SortDirection.tsx
+++ b/src/browser/components/pages/Streams/Settings/SortDirection.tsx
@@ -37,6 +37,7 @@ const SortDirection: FC = () => {
     <Skeleton variant="circular" sx={loadingStyle} />
   ) : (
     <Tooltip
+      enterNextDelay={1000}
       title={<Typography>{t(sortDirection, [t(`${sortField}SortField`)])}</Typography>}
       placement="top"
     >

--- a/src/browser/components/pages/Streams/Settings/SortDirection.tsx
+++ b/src/browser/components/pages/Streams/Settings/SortDirection.tsx
@@ -32,7 +32,7 @@ const SortDirection: FC = () => {
       sortDirection:
         sortDirection === SortDirectionEnum.ASC ? SortDirectionEnum.DESC : SortDirectionEnum.ASC,
     });
-  console.log(sortDirection);
+
   return settingsIsLoading ? (
     <Skeleton variant="circular" sx={loadingStyle} />
   ) : (

--- a/src/browser/components/pages/Streams/Settings/SortDirection.tsx
+++ b/src/browser/components/pages/Streams/Settings/SortDirection.tsx
@@ -1,8 +1,9 @@
 import { FC, useContext } from "react";
-import { IconButton, Skeleton } from "@mui/material";
+import { IconButton, Skeleton, Tooltip, Typography } from "@mui/material";
 import SortIcon from "@mui/icons-material/Sort";
 import { StreamSettingsContext } from "@/browser/common/context/StreamsSettings";
 import { SortDirection as SortDirectionEnum } from "@/common/types/settings";
+import { t } from "@/common/helpers";
 
 const loadingStyle = {
   width: "0.75rem",
@@ -24,20 +25,25 @@ const buttonStyle = {
 const SortDirection: FC = () => {
   const { streamSettings, setStreamsSettings, settingsIsLoading } =
     useContext(StreamSettingsContext);
-  const { sortDirection } = streamSettings;
+  const { sortDirection, sortField } = streamSettings;
 
   const changeSortDirection = () =>
     setStreamsSettings({
       sortDirection:
         sortDirection === SortDirectionEnum.ASC ? SortDirectionEnum.DESC : SortDirectionEnum.ASC,
     });
-
+  console.log(sortDirection);
   return settingsIsLoading ? (
     <Skeleton variant="circular" sx={loadingStyle} />
   ) : (
-    <IconButton id="sortDirection" sx={buttonStyle} onClick={changeSortDirection}>
-      <SortIcon className={sortDirection === SortDirectionEnum.ASC ? "asc" : "desc"} />
-    </IconButton>
+    <Tooltip
+      title={<Typography>{t(sortDirection, [t(`${sortField}SortField`)])}</Typography>}
+      placement="top"
+    >
+      <IconButton id="sortDirection" sx={buttonStyle} onClick={changeSortDirection}>
+        <SortIcon className={sortDirection === SortDirectionEnum.ASC ? "asc" : "desc"} />
+      </IconButton>
+    </Tooltip>
   );
 };
 

--- a/src/browser/components/pages/Streams/Settings/SortField.tsx
+++ b/src/browser/components/pages/Streams/Settings/SortField.tsx
@@ -1,7 +1,14 @@
 import { StreamSettingsContext } from "@/browser/common/context/StreamsSettings";
 import { t } from "@/common/helpers";
 import { SortField as SortFieldEnum } from "@/common/types/settings";
-import { MenuItem, Skeleton, StandardTextFieldProps, TextField } from "@mui/material";
+import {
+  MenuItem,
+  Skeleton,
+  StandardTextFieldProps,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
 import { ChangeEvent, FC, useContext } from "react";
 
 const loadingStyle = {
@@ -41,7 +48,7 @@ const sortFieldOptions: SortFieldEnum[] = Object.values(SortFieldEnum);
 const SortField: FC = () => {
   const { streamSettings, setStreamsSettings, settingsIsLoading } =
     useContext(StreamSettingsContext);
-  const { sortField } = streamSettings;
+  const { sortField, sortDirection } = streamSettings;
 
   const changeSortField = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
     setStreamsSettings({ sortField: e.target.value as SortFieldEnum });
@@ -49,13 +56,19 @@ const SortField: FC = () => {
   return settingsIsLoading ? (
     <Skeleton sx={loadingStyle} />
   ) : (
-    <TextField id="sortField" {...selectProps} value={sortField} onChange={changeSortField}>
-      {sortFieldOptions.map((option) => (
-        <MenuItem key={option} value={option}>
-          {t(`${option}SortField`)}
-        </MenuItem>
-      ))}
-    </TextField>
+    <Tooltip
+      enterNextDelay={1000}
+      title={<Typography>{t(sortDirection, [t(`${sortField}SortField`)])}</Typography>}
+      placement="top"
+    >
+      <TextField id="sortField" {...selectProps} value={sortField} onChange={changeSortField}>
+        {sortFieldOptions.map((option) => (
+          <MenuItem key={option} value={option}>
+            {t(`${option}SortField`)}
+          </MenuItem>
+        ))}
+      </TextField>
+    </Tooltip>
   );
 };
 

--- a/src/browser/components/pages/Streams/StreamsGroup.tsx
+++ b/src/browser/components/pages/Streams/StreamsGroup.tsx
@@ -43,7 +43,7 @@ const StreamsGroup: FC<StreamsGroupProps> = ({ key, group }) => {
         <Box className="header" onClick={toggleOpen}>
           <Typography>
             <ArrowDropDownIcon className={open ? "open" : ""} />
-            {groupBy === GroupBy.PLATFORM ? t(key) : key}
+            {groupBy === GroupBy.PLATFORM ? t(key) : key || t("noCategory")}
           </Typography>
         </Box>
       )}

--- a/src/browser/components/pages/Streams/StreamsList.tsx
+++ b/src/browser/components/pages/Streams/StreamsList.tsx
@@ -4,6 +4,7 @@ import { Box, Typography } from "@mui/material";
 import Loading from "../../layout/Loading/Loading";
 import { StreamSettingsContext } from "@/browser/common/context/StreamsSettings";
 import StreamsGroup from "./StreamsGroup";
+import useSettings from "@/browser/common/hooks/settings";
 
 const styles = {
   display: "flex",
@@ -25,10 +26,11 @@ const StreamsList: FC = () => {
   const { streamGroups, isLoading, settingsIsLoading, streamSettings } =
     useContext(StreamSettingsContext);
   const { search } = streamSettings;
+  const [, store] = useSettings();
 
   return (
     <Box id="streamsList" sx={styles}>
-      {isLoading || settingsIsLoading ? (
+      {isLoading || settingsIsLoading || store.isLoading ? (
         <Loading sx={loadingStyle} />
       ) : Object.keys(streamGroups).length ? (
         Object.keys(streamGroups)
@@ -39,7 +41,7 @@ const StreamsList: FC = () => {
       ) : (
         <Box className="empty">
           <Typography variant="body2">
-            {search === undefined ? t("noStreams") : t("noFilteredStreams")}
+            {search === "" ? t("noStreams") : t("noFilteredStreams")}
           </Typography>
         </Box>
       )}

--- a/src/browser/pages/popup.tsx
+++ b/src/browser/pages/popup.tsx
@@ -10,6 +10,8 @@ import { usePingError } from "../common/hooks/pingError";
 import BackgroundReset from "../components/modals/BackgroundReset";
 import useSettings from "../common/hooks/settings";
 import Loading from "../components/layout/Loading/Loading";
+import { useAllExpiredPlatforms } from "../common/hooks/platform";
+import PlatformExpiredModal from "../components/modals/PlatformExpired";
 
 const styles = {
   height: "550px",
@@ -20,6 +22,7 @@ const styles = {
 const Popup: FC = () => {
   const [, { isLoading }] = useSettings();
   const [error] = usePingError();
+  const expiredPlatform = useAllExpiredPlatforms();
 
   return (
     <Box id="root" sx={styles}>
@@ -43,7 +46,10 @@ const Popup: FC = () => {
               <Snackbar />
             </MainLayout>
           </SnackbarProvider>
-          <BackgroundReset isOpen={!!error} />
+          <BackgroundReset open={!!error} />
+          {expiredPlatform && (
+            <PlatformExpiredModal open={!!expiredPlatform} platformName={expiredPlatform.name} />
+          )}
         </>
       )}
     </Box>

--- a/src/browser/views/Settings.tsx
+++ b/src/browser/views/Settings.tsx
@@ -5,6 +5,7 @@ import GeneralSettings from "../components/pages/Settings/General";
 import NotificationsSettings from "../components/pages/Settings/Notifications";
 import ExtraSettings from "../components/pages/Settings/Extra";
 import PlatformsSettings from "../components/pages/Settings/Platforms";
+import StreamCardSettings from "../components/pages/Settings/StreamCardSettings";
 
 const styles = {
   display: "flex",
@@ -23,32 +24,40 @@ const styles = {
   },
 };
 
+const settings = [
+  {
+    label: t("generalSettings"),
+    component: <GeneralSettings />,
+  },
+  {
+    label: t("profileSettings"),
+    component: <PlatformsSettings />,
+  },
+  {
+    label: t("customStreamCard"),
+    component: <StreamCardSettings />,
+  },
+  {
+    label: t("notificationsSettings"),
+    component: <NotificationsSettings />,
+  },
+  {
+    label: t("exportAndImportSettings"),
+    component: <ExtraSettings />,
+  },
+];
+
 const Settings: FC = () => {
   return (
     <Box id="settings" sx={styles}>
-      <Divider className="divider">
-        <Typography>{t("generalSettings")}</Typography>
-      </Divider>
-
-      <GeneralSettings />
-
-      <Divider className="divider">
-        <Typography>{t("profileSettings")}</Typography>
-      </Divider>
-
-      <PlatformsSettings />
-
-      <Divider className="divider">
-        <Typography>{t("notificationsSettings")}</Typography>
-      </Divider>
-
-      <NotificationsSettings />
-
-      <Divider className="divider">
-        <Typography>{t("exportAndImportSettings")}</Typography>
-      </Divider>
-
-      <ExtraSettings />
+      {settings.map(({ label, component }) => (
+        <>
+          <Divider className="divider">
+            <Typography>{label}</Typography>
+          </Divider>
+          {component}
+        </>
+      ))}
     </Box>
   );
 };

--- a/src/common/types/settings.ts
+++ b/src/common/types/settings.ts
@@ -1,3 +1,5 @@
+import { StreamCardSettings } from "./stream";
+
 export enum FontSize {
   SMALLEST = "smallest",
   SMALL = "small",
@@ -31,6 +33,8 @@ export interface GeneralSettings {
   fontSize: FontSize;
   theme: Theme;
   badge: boolean;
+  useCustomStreamCard: boolean;
+  customStreamCard: StreamCardSettings;
 }
 
 export interface NotificationSettings {
@@ -59,6 +63,14 @@ export const defaultSettings: Settings = {
     fontSize: FontSize.MEDIUM,
     theme: Theme.DARK,
     badge: true,
+    useCustomStreamCard: false,
+    customStreamCard: {
+      thumbnail: true,
+      platformIcon: true,
+      viewers: true,
+      title: true,
+      category: true,
+    },
   },
   notifications: {
     enabled: true,

--- a/src/common/types/stream.ts
+++ b/src/common/types/stream.ts
@@ -22,3 +22,11 @@ export interface StreamError {
   message: string;
   platform: PlatformName;
 }
+
+export interface StreamCardSettings {
+  thumbnail: boolean;
+  platformIcon: boolean;
+  viewers: boolean;
+  title: boolean;
+  category: boolean;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1196,33 +1196,46 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@jridgewell/gen-mapping@^0.3.0":
-  version "0.3.1"
-  resolved "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.1.tgz#cf92a983c83466b8c0ce9124fadeaf09f7c66ea9"
-  integrity sha512-GcHwniMlA2z+WFPWuY8lp3fsza0I8xPFMWL5+n8LYyP6PSvPrXf4+n8stDHZY2DM0zy9sVkRDy1jDI4XGzYVqg==
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz#c1aedc61e853f2bb9f5dfe6d4442d3b565b253b9"
+  integrity sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==
   dependencies:
-    "@jridgewell/set-array" "^1.0.0"
+    "@jridgewell/set-array" "^1.0.1"
     "@jridgewell/sourcemap-codec" "^1.4.10"
     "@jridgewell/trace-mapping" "^0.3.9"
 
 "@jridgewell/resolve-uri@^3.0.3":
-  version "3.0.7"
-  resolved "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz#30cd49820a962aff48c8fffc5cd760151fca61fe"
-  integrity sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
+  integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
 
 "@jridgewell/set-array@^1.0.0":
   version "1.1.1"
   resolved "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz#36a6acc93987adcf0ba50c66908bd0b70de8afea"
   integrity sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==
 
+"@jridgewell/set-array@^1.0.1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
+  integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
+
+"@jridgewell/source-map@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/source-map/-/source-map-0.3.2.tgz#f45351aaed4527a298512ec72f81040c998580fb"
+  integrity sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.0"
+    "@jridgewell/trace-mapping" "^0.3.9"
+
 "@jridgewell/sourcemap-codec@^1.4.10":
-  version "1.4.13"
-  resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz#b6461fb0c2964356c469e115f504c95ad97ab88c"
-  integrity sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==
+  version "1.4.14"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
+  integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
 
 "@jridgewell/trace-mapping@^0.3.9":
-  version "0.3.13"
-  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz#dcfe3e95f224c8fe97a87a5235defec999aa92ea"
-  integrity sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==
+  version "0.3.14"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz#b231a081d8f66796e475ad588a1ef473112701ed"
+  integrity sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
@@ -2042,7 +2055,7 @@ browserslist@^4.12.0, browserslist@^4.14.5, browserslist@^4.20.2, browserslist@^
 
 buffer-from@^1.0.0:
   version "1.1.2"
-  resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
 bytes@^3.0.0:
@@ -2237,7 +2250,7 @@ colorette@^2.0.14, colorette@^2.0.16:
 
 commander@^2.20.0:
   version "2.20.3"
-  resolved "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 commander@^7.0.0:
@@ -3784,11 +3797,6 @@ lodash.merge@^4.6.2:
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash.sortby@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
-  integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
-
 lodash.topath@^4.5.2:
   version "4.5.2"
   resolved "https://registry.npmjs.org/lodash.topath/-/lodash.topath-4.5.2.tgz#3616351f3bba61994a0931989660bd03254fd009"
@@ -4803,7 +4811,7 @@ source-map-js@^1.0.2:
 
 source-map-support@~0.5.20:
   version "0.5.21"
-  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
   integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
   dependencies:
     buffer-from "^1.0.0"
@@ -4823,13 +4831,6 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0:
   version "0.6.1"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
-
-source-map@~0.8.0-beta.0:
-  version "0.8.0-beta.0"
-  resolved "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz#d4c1bb42c3f7ee925f005927ba10709e0d1d1f11"
-  integrity sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==
-  dependencies:
-    whatwg-url "^7.0.0"
 
 sourcemap-codec@^1.4.8:
   version "1.4.8"
@@ -5050,13 +5051,13 @@ terser-webpack-plugin@^5.1.3:
     terser "^5.7.2"
 
 terser@^5.10.0, terser@^5.7.2:
-  version "5.13.1"
-  resolved "https://registry.npmjs.org/terser/-/terser-5.13.1.tgz#66332cdc5a01b04a224c9fad449fc1a18eaa1799"
-  integrity sha512-hn4WKOfwnwbYfe48NgrQjqNOH9jzLqRcIfbYytOXCOv46LBfWr9bDS17MQqOi+BWGD0sJK3Sj5NC/gJjiojaoA==
+  version "5.14.2"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.14.2.tgz#9ac9f22b06994d736174f4091aa368db896f1c10"
+  integrity sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==
   dependencies:
+    "@jridgewell/source-map" "^0.3.2"
     acorn "^8.5.0"
     commander "^2.20.0"
-    source-map "~0.8.0-beta.0"
     source-map-support "~0.5.20"
 
 text-table@^0.2.0:
@@ -5102,13 +5103,6 @@ toggle-selection@^1.0.6:
   version "1.0.6"
   resolved "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
   integrity sha1-bkWxJj8gF/oKzH2J14sVuL932jI=
-
-tr46@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
-  integrity sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=
-  dependencies:
-    punycode "^2.1.0"
 
 ts-easing@^0.2.0:
   version "0.2.0"
@@ -5258,11 +5252,6 @@ webextension-polyfill@^0.9.0:
   resolved "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.9.0.tgz#de6c1941d0ef1b0858b20e9c7b46bbc042c5a960"
   integrity sha512-LTtHb0yR49xa9irkstDxba4GATDAcDw3ncnFH9RImoFwDlW47U95ME5sn5IiQX2ghfaECaf6xyXM8yvClIBkkw==
 
-webidl-conversions@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
-  integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
-
 webpack-cli@^4.9.2:
   version "4.9.2"
   resolved "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.2.tgz#77c1adaea020c3f9e2db8aad8ea78d235c83659d"
@@ -5323,15 +5312,6 @@ webpack@^5.72.0:
     terser-webpack-plugin "^5.1.3"
     watchpack "^2.3.1"
     webpack-sources "^3.2.3"
-
-whatwg-url@^7.0.0:
-  version "7.1.0"
-  resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz#c2c492f1eca612988efd3d2266be1b9fc6170d06"
-  integrity sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==
-  dependencies:
-    lodash.sortby "^4.7.0"
-    tr46 "^1.0.1"
-    webidl-conversions "^4.0.2"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2001,7 +2001,7 @@ balanced-match@^1.0.0:
 
 big.js@^5.2.2:
   version "5.2.2"
-  resolved "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
+  resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
 binary-extensions@^2.0.0:
@@ -2561,7 +2561,7 @@ emoji-regex@^9.2.2:
 
 emojis-list@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
+  resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
   integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
 
 enhanced-resolve@^5.9.2:
@@ -3631,7 +3631,7 @@ json5@^1.0.1:
 
 json5@^2.1.2, json5@^2.2.1:
   version "2.2.1"
-  resolved "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
   integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
 
 jsonfile@^6.0.1:
@@ -3736,9 +3736,9 @@ loader-runner@^4.2.0:
   integrity sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==
 
 loader-utils@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz#d6e3b4fb81870721ae4e0868ab11dd638368c129"
-  integrity sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
+  integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
   dependencies:
     big.js "^5.2.2"
     emojis-list "^3.0.0"


### PR DESCRIPTION
- added expired token dialog, which appears on extension load if one of the platforms, which uses the access token to get stream data, has an expired access token. Dialog options suggest renewing the access token or removing the profile.
- added stream card customization options, which allows user to hide stream thumbnail, platform icon, viewers count, title and/or category
- added stream card skeleton mainly for low-end PCs which can't handle quick local storage access
- sort field and direction now apply to groups (e.g. while sorting by viewers count ascending, the first group will be a group with a min-sum of viewers)
- fixed stream card layout when no title/category was specified
- added no category label for streams that have not specified their category
- added tooltips for a group by, sort field and direction options
- fixed settings skeletons
- resolved dependabot security dependencies